### PR TITLE
Fix/bok bugs9

### DIFF
--- a/src/components/common/product/LightboxModal.jsx
+++ b/src/components/common/product/LightboxModal.jsx
@@ -3,12 +3,38 @@
 import React, { useEffect } from "react";
 import { X, ChevronLeft, ChevronRight } from "lucide-react";
 
-export default function LightboxModal({ images = [], index = 0, onClose, onPrev, onNext }) {
+export default function LightboxModal({ 
+  images = [], 
+  index = 0, 
+  onClose,
+  onChange,
+  onSelect, 
+  onPrev, 
+  onNext 
+}) {
+  const len = images.length;
+
+  if (!len) return null;
+  const clamp = (i) => (i + len) % len;
+
+  const changeTo = (i) => {
+    if (onChange) onChange(clamp(i));
+    else if (onSelect) onSelect(clamp(i));
+  };
+  const prev = () => {
+    if (onPrev) onPrev();
+    else changeTo(index - 1);
+  };
+  const next = () => {
+    if (onNext) onNext();
+    else changeTo(index + 1);
+  };
+
   useEffect(() => {
     const onKey = (e) => {
       if (e.key === "Escape") onClose?.();
-      if (e.key === "ArrowLeft") onPrev?.();
-      if (e.key === "ArrowRight") onNext?.();
+      if (e.key === "ArrowLeft") prev?.();
+      if (e.key === "ArrowRight") next?.();
     };
     window.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
@@ -16,7 +42,7 @@ export default function LightboxModal({ images = [], index = 0, onClose, onPrev,
       window.removeEventListener("keydown", onKey);
       document.body.style.overflow = "";
     };
-  }, [onClose, onPrev, onNext]);
+  }, [prev, next, onClose]);
 
   if (!images.length) return null;
   const src = images[index];
@@ -38,17 +64,17 @@ export default function LightboxModal({ images = [], index = 0, onClose, onPrev,
         </button>
       </div>
       {/* 좌/우 네비게이션 */}
-      {images.length > 1 && (
+      {len > 1 && (
         <>
           <button
-            onClick={(e) => { e.stopPropagation(); onPrev?.(); }}
+            onClick={(e) => { e.stopPropagation(); prev(); }}
             className="absolute left-4 md:left-8 top-1/2 -translate-y-1/2 text-white/90 hover:text-white"
             aria-label="prev"
           >
             <ChevronLeft size={40} />
           </button>
           <button
-            onClick={(e) => { e.stopPropagation(); onNext?.(); }}
+            onClick={(e) => { e.stopPropagation(); next(); }}
             className="absolute right-4 md:right-8 top-1/2 -translate-y-1/2 text-white/90 hover:text-white"
             aria-label="next"
           >
@@ -58,13 +84,16 @@ export default function LightboxModal({ images = [], index = 0, onClose, onPrev,
       )}
 
       {/* 하단 썸네일 네비 */}
-      {images.length > 1 && (
+      {len > 1 && (
         <div className="absolute bottom-4 left-0 right-0 z-10 flex justify-center gap-2 px-4">
           <div className="flex gap-2 overflow-x-auto max-w-[90vw]">
             {images.map((s, i) => (
               <button
                 key={i}
-                onClick={(e) => { e.stopPropagation(); if (i < index) onPrev?.(i); else if (i > index) onNext?.(i); }}
+                onClick={(e) => { 
+                  e.stopPropagation(); 
+                  if (i !== index) changeTo(i);
+                }}
                 className={`h-24 w-12 md:w-16 rounded overflow-hidden border ${i === index ? "border-white" : "border-white/30"}`}
                 aria-label={`thumb-${i}`}
               >

--- a/src/components/common/product/LightboxModal.jsx
+++ b/src/components/common/product/LightboxModal.jsx
@@ -12,7 +12,7 @@ export default function LightboxModal({
   onPrev, 
   onNext 
 }) {
-  const len = images.length;
+  const len = images?.length;
 
   if (!len) return null;
   const clamp = (i) => (i + len) % len;

--- a/src/components/common/product/ProductDetail.jsx
+++ b/src/components/common/product/ProductDetail.jsx
@@ -36,6 +36,8 @@ export default function ProductDetail({ product, onAddToCart, onToast }) {
   const navigate = useNavigate();
   const { showModal, ModalComponent } = useAlertModal();
   const [sizeGuideOpen, setSizeGuideOpen] = useState(false);
+  const [index, setIndex] = useState(0);
+  const imgs = product?.gallery ?? [];
 
   useEffect(() => {
     const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)');
@@ -58,7 +60,7 @@ Object.fromEntries(
   const [lightboxIndex, setLightboxIndex] = useState(0);
 
   const openLightbox = (i) => {
-    setLightboxIndex(i);
+    setIndex(i);
     setLightboxOpen(true);
   };
   const closeLightbox = () => setLightboxOpen(false);
@@ -202,7 +204,7 @@ Object.fromEntries(
       <section className="grid grid-cols-1 lg:grid-cols-12 gap-8 mb-10">
         <div className="order-1 lg:order-1 lg:col-span-8">
           <ProductGallery
-            images={product.gallery}
+            images={imgs}
             onOpenLightbox={openLightbox}
           />
         </div>
@@ -328,11 +330,10 @@ Object.fromEntries(
       {/* 라이트박스 */}
       {lightboxOpen && (
         <LightboxModal
-          images={product.gallery}
-          index={lightboxIndex}
+          images={imgs}
+          index={index}
+          onChange={setIndex}
           onClose={closeLightbox}
-          onPrev={prevLightbox}
-          onNext={nextLightbox}
         />
       )}
 

--- a/src/components/common/product/ProductDetail.jsx
+++ b/src/components/common/product/ProductDetail.jsx
@@ -57,19 +57,12 @@ Object.fromEntries(
  ).toString();
 
   const [lightboxOpen, setLightboxOpen] = useState(false);
-  const [lightboxIndex, setLightboxIndex] = useState(0);
 
   const openLightbox = (i) => {
     setIndex(i);
     setLightboxOpen(true);
   };
   const closeLightbox = () => setLightboxOpen(false);
-  const prevLightbox = () =>
-    setLightboxIndex(
-      (i) => (i - 1 + product.gallery.length) % product.gallery.length
-    );
-  const nextLightbox = () =>
-    setLightboxIndex((i) => (i + 1) % product.gallery.length);
 
   useEffect(() => {
     try {
@@ -88,6 +81,13 @@ Object.fromEntries(
 
   useEffect(() => {
     let mounted = true;
+
+    if (!isLoggedIn) {
+      setWish(false);
+      setWishId(null);
+      return;
+    }
+
     (async () => {
       try {
         const rows = await listWishlist();
@@ -328,7 +328,7 @@ Object.fromEntries(
       </section>
 
       {/* 라이트박스 */}
-      {lightboxOpen && (
+      {lightboxOpen && imgs.length > 0 && (
         <LightboxModal
           images={imgs}
           index={index}

--- a/src/pages/Wishlist.jsx
+++ b/src/pages/Wishlist.jsx
@@ -14,10 +14,16 @@ import {
   moveWishlistToCart,
   removeWishlist,
 } from "../components/common/api/public/wishlist";
+import { useAuth } from "../context/AuthContext";
+import { useLocation, useNavigate } from "react-router-dom";
+import CartLoadingSpin from "../components/features/cart/CartLoadingSpin";
 
 export default function Wishlist() {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
+  const { isLoggedIn, bootstrapping } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const [selected, setSelected] = useState(new Set());
   const [cartCount, setCartCount] = useState(0);
@@ -31,7 +37,17 @@ export default function Wishlist() {
   const indeterminate = selected.size > 0 && !allChecked;
   const isEmpty = !loading && items.length === 0;
 
+  // 사용자가 로그인되었는지 확인 -> 아닐경우 로그인페이지로 바로 리다이렉트
   useEffect(() => {
+    if (bootstrapping) return;
+    if (!isLoggedIn) {
+      navigate("/login", { replace: true, state: { from: location.pathname } });
+    }
+  }, [bootstrapping, isLoggedIn, navigate, location.pathname]);
+
+  // 로그인했을 경우 이동시킴, 에러는 토스트알람으로 확인될 수 있게 설정
+  useEffect(() => {
+    if (bootstrapping || !isLoggedIn) return;
     let mounted = true;
     (async () => {
       try {
@@ -46,10 +62,8 @@ export default function Wishlist() {
         setLoading(false);
       }
     })();
-    return () => {
-      mounted = false;
-    };
-  }, []);
+    return () => { mounted = false; };
+  }, [bootstrapping, isLoggedIn]);
 
   const toggleAll = () => {
     if (allChecked) setSelected(new Set());
@@ -146,6 +160,8 @@ export default function Wishlist() {
       pushToast("일부 항목 담기에 실패했어요.");
     }
   };
+  // 로딩스피너 사용하여 진행중이라는걸 보여주기.
+  const showOverlayLoading = bootstrapping || (loading && items.length === 0);
 
   return (
     <motion.div
@@ -202,6 +218,7 @@ export default function Wishlist() {
 
       {/* 토스트 */}
       <Toasts toasts={toasts} />
-    </motion.div>
+      {showOverlayLoading && <CartLoadingSpin />}
+    </motion.div>    
   );
 }


### PR DESCRIPTION
1. 지난주 멘토님께서 지적해주셨던 상품 이미지 확대해서 보여줄 때 순서가 불규칙적인거 지적해주신 부분 수정
- 인덱스변경은 onChange(i)로 통일하였으며, prev/next는 항상 1칸만 이동하게 설정
[thumbnail.webm](https://github.com/user-attachments/assets/181ed2d0-eb1f-41d0-8927-08c8c8781534)
2. 디테일 페이지 진입 시, 위시리스트 관련 콘솔에러 와장창뜸 -> isLoggedIn 조건으로 호출 차단, 장바구니는 했는데 위시리스트는 제대로 적용안되어 있어서 오류가 뜨고 잇엇음.
3. 비회원인데 위시리스트 페이지 진입하려고 할 경우, 로그인페이지로 리다이렉트 (기존 토스트알림으로 와장창떠서 보기 흉했음...)

이상입니다. 