### PR TITLE
fix: 배송지가 없는경우 결제가 넘어가는 문제 해결

### DIFF
--- a/src/pages/Payments/UserPayment.jsx
+++ b/src/pages/Payments/UserPayment.jsx
@@ -190,6 +190,11 @@ export default function UserPayment() {
         }));
       }
     }
+    // 기본 배송지가 없다면. 기본배송지 상태 false
+    else if(myAddress && myAddress.length === 0){
+      setIsDefaultAddress(false)
+    }
+    console.log(myAddress, '기본 주소')
   }, [myAddress]);
 
   // 배송지 변경사항 저장
@@ -457,6 +462,7 @@ export default function UserPayment() {
               className={`text-gray-500 text-center border rounded-sm border-gray-300 px-0.5 w-[90px]
               cursor-pointer select-none`}
               onClick={handleAddressListModalOpen}
+              disabled={myAddress.length === 0}
             >
               {/* 기본 배송지 */}
               배송지 선택


### PR DESCRIPTION
소셜로그인등, 특수한 상황에서 배송지가 전혀 없는 경우에 IsDefaultAddress 상태가 true여서 바로 넘어가게됨

따라서 배송지가 없으면 IsDefaultAddress를 false로 변경할 수 있도록 코드를 추가 했습니다.